### PR TITLE
Fix MD5 on RHEL boxes using FIPS

### DIFF
--- a/bin/clamavmirror
+++ b/bin/clamavmirror
@@ -85,7 +85,10 @@ def get_file_md5(filename):
     """Get a file's MD5"""
     if os.path.exists(filename):
         blocksize = 65536
-        hasher = hashlib.md5()
+        try:
+            hasher = hashlib.md5()
+        except:
+            hasher = hashlib.new('md5', usedForSecurity=False)
         with open(filename, 'rb') as afile:
             buf = afile.read(blocksize)
             while len(buf) > 0:
@@ -98,7 +101,10 @@ def get_file_md5(filename):
 
 def get_md5(string):
     """Get a string's MD5"""
-    hasher = hashlib.md5()
+    try:
+        hasher = hashlib.md5()
+    except:
+        hasher = hashlib.new('md5', usedForSecurity=False)
     hasher.update(string)
     return hasher.hexdigest()
 


### PR DESCRIPTION
Use the usedForSecurity=False flag to permit usage of MD5 hash when
FIPS is enabled

Copied from https://github.com/Cisco-Talos/clamav-faq/pull/86/files
by @AfroThundr3007730

Fixes #2