### PR TITLE
Update user-agent to LTS version

### DIFF
--- a/clamavmirror/__init__.py
+++ b/clamavmirror/__init__.py
@@ -205,7 +205,7 @@ def download_sig(opts, sig, version=None):
     """Download signature from hostname"""
     code = None
     downloaded = False
-    useagent = 'ClamAV/0.101.1 (OS: linux-gnu, ARCH: x86_64, CPU: x86_64)'
+    useagent = 'ClamAV/0.103.0 (OS: linux-gnu, ARCH: x86_64, CPU: x86_64)'
     manager = PoolManager(
         headers=make_headers(user_agent=useagent),
         cert_reqs='CERT_REQUIRED',


### PR DESCRIPTION
Version currently set as user-agent is since 2022-01-03 no longer supported, causing mirror updates to fail.
This PR set user-agent to 103.0 which is a LTS version which should be supported till 2023-09-14
see also: https://docs.clamav.net/faq/faq-eol.html#regular-non-lts-feature-releases